### PR TITLE
Fix murmur2 for unicode values

### DIFF
--- a/murmurhash2_gc.js
+++ b/murmurhash2_gc.js
@@ -12,16 +12,16 @@
  */
 
 function murmurhash2_32_gc(key, seed) {
+  if (!Buffer.isBuffer(key)) {
+    key = new Buffer(key);
+  }
+
   seed = seed || 0x01234567;
   var l = key.length;
   var h = seed ^ l;
   var i = 0;
   var k;
   
-  if (!Buffer.isBuffer(key)) {
-    key = new Buffer(key);
-  }
-
   while (l >= 4) {
     k = key.readInt32LE(i, i + 4);
     k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));

--- a/test.js
+++ b/test.js
@@ -10,6 +10,10 @@ describe('murmur', function() {
         expect(murmur.murmur2(key)).to.equal(value);
       });
     });
+
+    it('should handle unicode properly', function() {
+      expect(murmur.murmur2('\u263a')).to.equal(422544450);
+    });
   });
   describe('murmur3', function() {
     it('should generate expected values', function() {


### PR DESCRIPTION
`key.length !== Buffer(key).length` because unicode characters are multiple bytes. Move the `isBuffer` check before setting `var l = key.length;`.

Only `murmur2` had this issue. `murmur3` worked as expected.
