### PR TITLE
Make possible to set the seed to 0

### DIFF
--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -20,7 +20,7 @@ function murmurhash3_32_gc(key, seed) {
   
   remainder = key.length & 3; // key.length % 4
   bytes = key.length - remainder;
-  h1 = seed || 0x01234567;
+  h1 = (typeof seed === 'undefined') ? 0x01234567 : seed;
   c1 = 0xcc9e2d51;
   c2 = 0x1b873593;
   i = 0;


### PR DESCRIPTION
In the current version it is not possible to set the seed to `0` as it would be changed to the default seed of `0x01234567`.

This small patch allows you to set the seed to 0 while maintaining the previous default in case you don't specify any seed.
